### PR TITLE
Add missing `npm install` in generator folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Install Yeoman and then link the generator.
 npm install
 npm install -g yo
 cd generator-cspell-dicts-extensions
+npm install
 npm link
 cd ..
 ```


### PR DESCRIPTION
Running `yo cspell-dict-extensions <name>` fails without this.