### PR TITLE
chore: move to node16 settings of TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lerna-lite/cli": "^1.12.0",
         "@lerna-lite/exec": "^1.12.0",
         "@lerna-lite/run": "^1.12.0",
-        "@tsconfig/node14": "^1.0.3",
+        "@tsconfig/node16": "^1.0.3",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.7",
         "@types/vscode": "^1.72.0",
@@ -1392,10 +1392,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node14": {
+    "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -9744,10 +9744,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tsconfig/node14": {
+    "@tsconfig/node16": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@lerna-lite/cli": "^1.12.0",
     "@lerna-lite/run": "^1.12.0",
     "@lerna-lite/exec": "^1.12.0",
-    "@tsconfig/node14": "^1.0.3",
+    "@tsconfig/node16": "^1.0.3",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.7",
     "@types/vscode": "^1.72.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "CSpell Monorepo Base Config",
-    "extends": "@tsconfig/node14/tsconfig.json",
+    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
         "alwaysStrict": true,
         "declaration": true,


### PR DESCRIPTION
VS Code use node 16, so should we.