### PR TITLE
Serbian

### DIFF
--- a/extensions/serbian/README.md
+++ b/extensions/serbian/README.md
@@ -22,7 +22,16 @@ After this extension is installed, it is necessary to tell the spell checker to 
 
 ### Enable/disable dictionaries via commands
 
-You can also use commands (`F1` or _View -> Command Palette..._) to enable Serbian dictionaries.
+You can also use the following commands (`F1` or _View -> Command Palette..._) to enable or disable Serbian dictionaries:
+
+- `Enable Serbian Spell Checker Dictionary`
+- `Disable Serbian Spell Checker Dictionary`
+- `Enable Serbian Cyrillic Spell Checker Dictionary`
+- `Disable Serbian Cyrillic Spell Checker Dictionary`  
+- `Enable Serbian Latin Spell Checker Dictionary`
+- `Disable Serbian Latin Spell Checker Dictionary`
+- `Enable Serbian Spell Checker Dictionary in Workspace`
+- `Disable Serbian Spell Checker Dictionary in Workspace`
 
 ![Commands dropdown for enabling and disabling Serbian dictionaries](https://i.imgur.com/3DPWwFV.png)
 

--- a/extensions/serbian/README.md
+++ b/extensions/serbian/README.md
@@ -8,21 +8,23 @@ Imports the Serbian (both Cyrillic and Latin) spellchecking dictionaries for [Co
 
 After this extension is installed, it is necessary to tell the spell checker to use it.
 
-### Enable Dictionary
+### Enable Dictionaries
 
-Commands (use `F1` or _View -> Command Palette..._):
+- `F1` `Show Spell Checker Configuration Info` (or click on the "Spell" icon in the status bar)
+- Enable the language globally in the `User` tab or in just in the `Workspace` tab.
 
-- `F1` `Show Spell Checker Configuration Info`
-- Select the `Language` tab.
-- Enable the language Globally or in just the Workspace.
+![Selected dictionaries in the Spell Checker User Tab](https://i.imgur.com/78LApWC.png)
 
-### Disable Dictionary
+### Disable Dictionaries
 
-Commands (use `F1` or _View -> Command Palette..._):
+- `F1` `Show Spell Checker Configuration Info` (or click on the "Spell" icon in the status bar)
+- Disable the language globally in the `User` tab or in just in the `Workspace` tab.
 
-- `F1` `Show Spell Checker Configuration Info`
-- Select the `Language` tab.
-- Disable the language Globally or in just the Workspace.
+### Enable/disable dictionaries via commands
+
+You can also use commands (`F1` or _View -> Command Palette..._) to enable Serbian dictionaries.
+
+![Commands dropdown for enabling and disabling Serbian dictionaries](https://i.imgur.com/3DPWwFV.png)
 
 ### Manual Settings
 
@@ -31,11 +33,14 @@ This is done with the `language` setting.
 _Preferences_ -> _Settings_
 
 Adding `sr` to the `cSpell.language` setting, will enable the Serbian dictionaries, both Cyrillic and Latin.
+
 Example using both English and Serbian dictionaries:
 
 ```javascript
 "cSpell.language": "en,sr",
 ```
+
+To enable only Cyrillic or Latin, use the specific locales: `sr-Cyrl` or `sr-Latn`.
 
 ## Requirements
 

--- a/extensions/serbian/package.json
+++ b/extensions/serbian/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.1",
   "displayName": "Serbian - Code Spell Checker",
   "icon": "images/SpellCheck.png",
-  "preview": true,
   "private": true,
   "publisher": "streetsidesoftware",
   "license": "GPL-3.0-or-later",

--- a/extensions/serbian/samples/cspell.json
+++ b/extensions/serbian/samples/cspell.json
@@ -1,3 +1,3 @@
 {
-    "language": "en"
+    "language": "sr"
 }


### PR DESCRIPTION
Thanks a lot @Jason3S for creating script-based commands.

This PR fixes the cspell language for the serbian sample and updates the README to explain in more detail how `sr`, `sr-Cyrl` and `sr-Latn` work. 