### PR TITLE
fix: Add `capabilities` to manifest

### DIFF
--- a/extensions/arabic/package.json
+++ b/extensions/arabic/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/australian-english/package.json
+++ b/extensions/australian-english/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/austrian-german/package.json
+++ b/extensions/austrian-german/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/basque/package.json
+++ b/extensions/basque/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/british-english/package.json
+++ b/extensions/british-english/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/bulgarian/package.json
+++ b/extensions/bulgarian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/canadian-english/package.json
+++ b/extensions/canadian-english/package.json
@@ -36,6 +36,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/catalan/package.json
+++ b/extensions/catalan/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/croatian/package.json
+++ b/extensions/croatian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/czech/package.json
+++ b/extensions/czech/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/danish/package.json
+++ b/extensions/danish/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/dutch/package.json
+++ b/extensions/dutch/package.json
@@ -32,6 +32,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/esperanto/package.json
+++ b/extensions/esperanto/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/estonian/package.json
+++ b/extensions/estonian/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/french-reforme/package.json
+++ b/extensions/french-reforme/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/french/package.json
+++ b/extensions/french/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/german/package.json
+++ b/extensions/german/package.json
@@ -32,6 +32,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/greek/package.json
+++ b/extensions/greek/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/hebrew/package.json
+++ b/extensions/hebrew/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/hunspell-syntax/package.json
+++ b/extensions/hunspell-syntax/package.json
@@ -13,6 +13,12 @@
   "license": "MIT",
   "qna": "marketplace",
   "icon": "images/hunspell.png",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "languages": [
       {

--- a/extensions/italian/package.json
+++ b/extensions/italian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/latvian/package.json
+++ b/extensions/latvian/package.json
@@ -32,6 +32,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/lithuanian/package.json
+++ b/extensions/lithuanian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/medical-terms/package.json
+++ b/extensions/medical-terms/package.json
@@ -27,6 +27,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {},
   "extensionDependencies": [
     "streetsidesoftware.code-spell-checker"

--- a/extensions/norwegian-bokmal/package.json
+++ b/extensions/norwegian-bokmal/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/persian/package.json
+++ b/extensions/persian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/polish/package.json
+++ b/extensions/polish/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/portuguese-brazilian/package.json
+++ b/extensions/portuguese-brazilian/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/portuguese/package.json
+++ b/extensions/portuguese/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/romanian/package.json
+++ b/extensions/romanian/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/russian/package.json
+++ b/extensions/russian/package.json
@@ -25,6 +25,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/scientific-terms/package.json
+++ b/extensions/scientific-terms/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": []
   },

--- a/extensions/serbian/package.json
+++ b/extensions/serbian/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/slovak/package.json
+++ b/extensions/slovak/package.json
@@ -33,6 +33,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/slovenian/package.json
+++ b/extensions/slovenian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/spanish/package.json
+++ b/extensions/spanish/package.json
@@ -26,6 +26,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/swedish/package.json
+++ b/extensions/swedish/package.json
@@ -32,6 +32,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/swiss-german/package.json
+++ b/extensions/swiss-german/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/turkish/package.json
+++ b/extensions/turkish/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/ukrainian/package.json
+++ b/extensions/ukrainian/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/vietnamese/package.json
+++ b/extensions/vietnamese/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/extensions/win32/package.json
+++ b/extensions/win32/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {},
   "extensionDependencies": [
     "streetsidesoftware.code-spell-checker"

--- a/generator-cspell-dicts-extensions/generators/app/templates/package.json
+++ b/generator-cspell-dicts-extensions/generators/app/templates/package.json
@@ -34,6 +34,12 @@
   ],
   "qna": "marketplace",
   "main": "./out/extension.js",
+  "capabilities": {
+    "virtualWorkspaces": true,
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
         <% if (addCommands) { %>
         "commands": [


### PR DESCRIPTION
By default, these extensions should support: virtual workspaces and untrusted workspaces.