### PR TITLE
fix: Remove microsecond conversion

### DIFF
--- a/extensions/timestamp-hover/README.md
+++ b/extensions/timestamp-hover/README.md
@@ -2,7 +2,7 @@
 
 Display the ISO time and date while hovering over timestamps.
 
-- Automatically converts timestamps from seconds, milliseconds, or microseconds to ISO Time.
+- Automatically converts timestamps from seconds or milliseconds to ISO Time.
 - Does not convert timestamps before 1980 to avoid being noisy.
 
 ![Example](./images/Screenshot1.png)

--- a/extensions/timestamp-hover/src/extension.ts
+++ b/extensions/timestamp-hover/src/extension.ts
@@ -7,19 +7,22 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
     const options: FormatTimestampOptions = {
         minDate: new Date('1980-01-01'),
-    }
+    };
 
-    const hoverProvider = vscode.languages.registerHoverProvider({ scheme: '*', language: '*' }, {
-        provideHover(document, position) {
-            const range = document.getWordRangeAtPosition(position);
-            if (!range) {
-                return undefined;
-            }
-            const word = document.getText(range);
-            const hoverMessage = formatTimestamp(word, options);
-            return hoverMessage ? new vscode.Hover(`_${hoverMessage}_`) : undefined;
-        }
-    });
+    const hoverProvider = vscode.languages.registerHoverProvider(
+        { scheme: '*', language: '*' },
+        {
+            provideHover(document, position) {
+                const range = document.getWordRangeAtPosition(position);
+                if (!range) {
+                    return undefined;
+                }
+                const word = document.getText(range);
+                const hoverMessage = formatTimestamp(word, options);
+                return hoverMessage ? new vscode.Hover(`_${hoverMessage}_`) : undefined;
+            },
+        },
+    );
     context.subscriptions.push(hoverProvider);
 }
 
@@ -39,15 +42,18 @@ function formatTimestamp(text: string, options: FormatTimestampOptions): string 
         timestamp *= 1000;
     }
     if (timestamp > 1e14) {
-        // microseconds to milliseconds
-        timestamp /= 1000;
+        // too large
+        return undefined;
     }
     if (timestamp < options.minDate.getTime()) {
         return undefined;
     }
-    return new Date(timestamp).toISOString();
+    try {
+        return new Date(timestamp).toISOString();
+    } catch {
+        return undefined;
+    }
 }
-
 
 // this method is called when your extension is deactivated
 export function deactivate() {}


### PR DESCRIPTION
It doesn't make a lot of sense to keep microsecond conversion. Add it back later if needed.