### PR TITLE
chore: Use `npm install` instead of `npm ci` when updating depdencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -38,7 +38,7 @@ jobs:
           npx npm-check-updates -t semver -u
           rm -rf node_modules package-lock.json
       - name: Install
-        run: npm ci
+        run: npm i
       - name: Update packages
         run: |
           npm run update-packages


### PR DESCRIPTION
This pull request makes a small change to the dependency update workflow. The `Install` step now uses `npm i` instead of `npm ci`, to update the package-lock.json file.